### PR TITLE
Add ap123 link to appnotes page

### DIFF
--- a/docs/source/appnotes.rst
+++ b/docs/source/appnotes.rst
@@ -29,7 +29,7 @@ Formal Basics and Methods
 
 - `109 Property Checking with SVA <https://yosyshq.readthedocs.io/projects/ap109>`_
 - `120 Weak precondition cover and witness for SVA properties <https://yosyshq.readthedocs.io/projects/ap120>`_
-- `123 Advanced SBY Use by Example <https://yosyshq.readthedocs.io/projects/ap123>`
+- `123 Advanced SBY Use by Example <https://yosyshq.readthedocs.io/projects/ap123>`_
 
 ..
   Formal Abstractions

--- a/docs/source/appnotes.rst
+++ b/docs/source/appnotes.rst
@@ -29,6 +29,7 @@ Formal Basics and Methods
 
 - `109 Property Checking with SVA <https://yosyshq.readthedocs.io/projects/ap109>`_
 - `120 Weak precondition cover and witness for SVA properties <https://yosyshq.readthedocs.io/projects/ap120>`_
+- `123 Advanced SBY Use by Example <https://yosyshq.readthedocs.io/projects/ap123>`
 
 ..
   Formal Abstractions


### PR DESCRIPTION
Currently titled 'Advanced SBY Use by Example', since that's what the git repo for 123 calls it, but the actual documentation just says AppNote 123 (pending YosysHQ-Docs/AppNote-123#1)